### PR TITLE
Fix missing logo on header and footer

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,8 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next'
 
-const isExport = process.env.NODE_ENV === 'production' || process.env.NEXT_PUBLIC_GITHUB_PAGES === 'true';
+const isExport =
+  process.env.NODE_ENV === 'production' ||
+  process.env.NEXT_PUBLIC_GITHUB_PAGES === 'true'
 
 const nextConfig: NextConfig = {
   images: {
@@ -8,6 +10,18 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'images.unsplash.com',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'hajila-bau.de',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: '**.github.io',
         port: '',
         pathname: '/**',
       },
@@ -27,6 +41,6 @@ const nextConfig: NextConfig = {
     'http://localhost',
     'http://127.0.0.1',
   ],
-};
+}
 
-export default nextConfig;
+export default nextConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "image-size": "^2.0.2",
         "lucide-react": "^0.523.0",
         "motion": "^12.22.0",
-        "next": "^15.3.4",
+        "next": "^15.3.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tailwind-merge": "^3.3.1",
@@ -47,7 +47,7 @@
         "@types/react-dom": "^19",
         "@types/three": "^0.177.0",
         "eslint": "^9",
-        "eslint-config-next": "15.3.4",
+        "eslint-config-next": "15.3.5",
         "gh-pages": "^6.3.0",
         "jest": "^30.0.4",
         "prettier": "^3",
@@ -2465,10 +2465,11 @@
       "integrity": "sha512-7g06v8BUVtN2njAX/r8gheoVffhiKFVt4nx74Tt6G4Hqw9HCLYQVx/GkH2qHvPtAHZaUNZ0VXAa0pQP6v1wk7g=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.3.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.3.4.tgz",
-      "integrity": "sha512-lBxYdj7TI8phbJcLSAqDt57nIcobEign5NYIKCiy0hXQhrUbTqLqOaSDi568U6vFg4hJfBdZYsG4iP/uKhCqgg==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.3.5.tgz",
+      "integrity": "sha512-BZwWPGfp9po/rAnJcwUBaM+yT/+yTWIkWdyDwc74G9jcfTrNrmsHe+hXHljV066YNdVs8cxROxX5IgMQGX190w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-glob": "3.3.1"
       }
@@ -6239,12 +6240,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.3.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.3.4.tgz",
-      "integrity": "sha512-WqeumCq57QcTP2lYlV6BRUySfGiBYEXlQ1L0mQ+u4N4X4ZhUVSSQ52WtjqHv60pJ6dD7jn+YZc0d1/ZSsxccvg==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.3.5.tgz",
+      "integrity": "sha512-oQdvnIgP68wh2RlR3MdQpvaJ94R6qEFl+lnu8ZKxPj5fsAHrSF/HlAOZcsimLw3DT6bnEQIUdbZC2Ab6sWyptg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.3.4",
+        "@next/eslint-plugin-next": "15.3.5",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",


### PR DESCRIPTION
### **User description**
## Summary
- allow loading logo from hajila-bau.de by adding the domain to Next.js image remotePatterns
- include GitHub Pages domain for image loading

## Testing
- `npm ci`
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test -- --runInBand` *(fails: No tests found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68717cd120348320983e77a75bb89953


___

### **PR Type**
Bug fix


___

### **Description**
- Add remote image patterns for logo loading

- Enable GitHub Pages domain image support

- Fix missing logo display on header/footer


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Next.js Config"] --> B["Add hajila-bau.de domain"]
  A --> C["Add GitHub Pages wildcard"]
  B --> D["Logo Loading Fixed"]
  C --> D
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next.config.ts</strong><dd><code>Add remote image patterns for logo support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

next.config.ts

<li>Add <code>hajila-bau.de</code> to remotePatterns for logo loading<br> <li> Add <code>**.github.io</code> wildcard pattern for GitHub Pages<br> <li> Update code formatting to single quotes<br> <li> Fix multiline variable declaration formatting


</details>


  </td>
  <td><a href="https://github.com/Jokerman890/hajila-bau-website/pull/16/files#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7b">+18/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>