### PR TITLE
fix: remove redundant favicon link

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -64,7 +64,6 @@ export default function RootLayout({
         <AuthProvider>
           {children}
         </AuthProvider>
-        <link rel="icon" type="image/jpeg" href="/uploads/Hexagon-logo.jpg" />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- remove duplicate favicon link from `layout.tsx`

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test -- --runInBand` *(fails: No tests found)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687291e75b4c83209e98104c3aeac2b6