### PR TITLE
feat: move stats and glow cards

### DIFF
--- a/src/components/ui/premium-website.tsx
+++ b/src/components/ui/premium-website.tsx
@@ -394,7 +394,7 @@ const PremiumWebsite: React.FC = () => {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Image
-                src={getAssetPath("/uploads/logo_2d.png")}
+                src={getAssetPath('/uploads/logo_2d.png')}
                 alt="Hajila Bau Logo"
                 width={48}
                 height={48}
@@ -500,6 +500,9 @@ const PremiumWebsite: React.FC = () => {
         </div>
       </section>
 
+      {/* Stats Section */}
+      <Stats />
+
       {/* Services Section (Features) - Integrated with GlowingServiceGrid */}
       <section id="services" className="relative z-10 py-20 px-6">
         <div className="mx-auto max-w-7xl">
@@ -582,7 +585,9 @@ const PremiumWebsite: React.FC = () => {
             className="flex justify-center mb-12"
           >
             <Image
-              src={getAssetPath("/uploads/Baustelle mit HB Logo und Mauern.png")}
+              src={getAssetPath(
+                '/uploads/Baustelle mit HB Logo und Mauern.png',
+              )}
               alt="Baustelle mit Hajila Bau Logo"
               width={800}
               height={450}
@@ -657,9 +662,6 @@ const PremiumWebsite: React.FC = () => {
         </div>
       </section>
 
-      {/* Stats Section - Updated for GitHub Pages */}
-      <Stats />
-
       {/* Contact Section */}
       <section id="contact" className="relative z-10 py-20 px-6">
         <div className="mx-auto max-w-4xl text-center">
@@ -721,7 +723,7 @@ const PremiumWebsite: React.FC = () => {
         <div className="mx-auto max-w-7xl text-center text-sm text-muted-foreground font-['Open_Sans']">
           <div className="flex justify-center items-center mb-4">
             <Image
-              src={getAssetPath("/uploads/logo_2d.png")}
+              src={getAssetPath('/uploads/logo_2d.png')}
               alt="Hajila Bau Logo"
               width={48}
               height={48}

--- a/src/components/ui/stats-section.tsx
+++ b/src/components/ui/stats-section.tsx
@@ -17,7 +17,10 @@ function Stats() {
 
         {/* Stats Grid */}
         <div className="grid text-center grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 w-full gap-6 lg:gap-8">
-          <div className="flex gap-0 flex-col justify-between items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
+          <div
+            className="flex gap-0 flex-col justify-between items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm transition-all duration-300 hover:scale-[1.02]"
+            style={{ boxShadow: '0 0 12px var(--gold)' }}
+          >
             <div className="p-3 rounded-full bg-primary/10 mb-6">
               <Building2 className="w-8 h-8 text-primary" />
             </div>
@@ -32,7 +35,10 @@ function Stats() {
             </p>
           </div>
 
-          <div className="flex gap-0 flex-col justify-between items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
+          <div
+            className="flex gap-0 flex-col justify-between items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm transition-all duration-300 hover:scale-[1.02]"
+            style={{ boxShadow: '0 0 12px var(--gold)' }}
+          >
             <div className="p-3 rounded-full bg-success/10 mb-6">
               <Users className="w-8 h-8 text-success" />
             </div>
@@ -47,7 +53,10 @@ function Stats() {
             </p>
           </div>
 
-          <div className="flex gap-0 flex-col justify-between items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
+          <div
+            className="flex gap-0 flex-col justify-between items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm transition-all duration-300 hover:scale-[1.02]"
+            style={{ boxShadow: '0 0 12px var(--gold)' }}
+          >
             <div className="p-3 rounded-full bg-blue-500/10 mb-6">
               <Hammer className="w-8 h-8 text-blue-600" />
             </div>
@@ -62,7 +71,10 @@ function Stats() {
             </p>
           </div>
 
-          <div className="flex gap-0 flex-col justify-between items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
+          <div
+            className="flex gap-0 flex-col justify-between items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm transition-all duration-300 hover:scale-[1.02]"
+            style={{ boxShadow: '0 0 12px var(--gold)' }}
+          >
             <div className="p-3 rounded-full bg-yellow-500/10 mb-6">
               <Trophy className="w-8 h-8 text-yellow-600" />
             </div>


### PR DESCRIPTION
## Summary
- relocate Stats section after hero on the homepage
- add glowing border effect to stats cards

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test -- --runInBand`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6880f97c410883209b65de2ade4afe40