### PR TITLE
feat: add gradient glow utility for stats

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @custom-variant dark (&:is(.dark *));
 
@@ -82,10 +82,10 @@
 
   /* Custom Colors for Hajila Bau */
   --blue-start: #000080; /* Dunkelblau */
-  --blue-end: #4169E1;   /* Royalblau */
-  --gold: #FFD700;       /* Gold */
-  --blue-500: #3B82F6;   /* Tailwind blue-500 */
-  --purple-600: #9333EA; /* Tailwind purple-600 */
+  --blue-end: #4169e1; /* Royalblau */
+  --gold: #ffd700; /* Gold */
+  --blue-500: #3b82f6; /* Tailwind blue-500 */
+  --purple-600: #9333ea; /* Tailwind purple-600 */
 }
 
 .dark {
@@ -125,10 +125,10 @@
 
   /* Custom Colors for Hajila Bau in Dark Mode */
   --blue-start: #000080; /* Dunkelblau */
-  --blue-end: #4169E1;   /* Royalblau */
-  --gold: #FFD700;       /* Gold */
-  --blue-500: #3B82F6;   /* Tailwind blue-500 */
-  --purple-600: #9333EA; /* Tailwind purple-600 */
+  --blue-end: #4169e1; /* Royalblau */
+  --gold: #ffd700; /* Gold */
+  --blue-500: #3b82f6; /* Tailwind blue-500 */
+  --purple-600: #9333ea; /* Tailwind purple-600 */
 }
 
 @layer base {
@@ -137,5 +137,40 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@keyframes spin-slow {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@layer utilities {
+  .animate-spin-slow {
+    animation: spin-slow 8s linear infinite;
+  }
+
+  .glow-border {
+    position: relative;
+    overflow: hidden;
+    padding: 1px;
+  }
+  .glow-border::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: conic-gradient(
+      var(--blue-500),
+      var(--purple-600),
+      var(--blue-500)
+    );
+    animation: spin-slow 8s linear infinite;
+    opacity: 0.7;
+    filter: blur(4px);
   }
 }

--- a/src/components/ui/premium-website.tsx
+++ b/src/components/ui/premium-website.tsx
@@ -394,7 +394,7 @@ const PremiumWebsite: React.FC = () => {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Image
-                src={getAssetPath("/uploads/logo_2d.png")}
+                src={getAssetPath('/uploads/logo_2d.png')}
                 alt="Hajila Bau Logo"
                 width={48}
                 height={48}
@@ -500,6 +500,9 @@ const PremiumWebsite: React.FC = () => {
         </div>
       </section>
 
+      {/* Stats Section */}
+      <Stats />
+
       {/* Services Section (Features) - Integrated with GlowingServiceGrid */}
       <section id="services" className="relative z-10 py-20 px-6">
         <div className="mx-auto max-w-7xl">
@@ -582,7 +585,9 @@ const PremiumWebsite: React.FC = () => {
             className="flex justify-center mb-12"
           >
             <Image
-              src={getAssetPath("/uploads/Baustelle mit HB Logo und Mauern.png")}
+              src={getAssetPath(
+                '/uploads/Baustelle mit HB Logo und Mauern.png',
+              )}
               alt="Baustelle mit Hajila Bau Logo"
               width={800}
               height={450}
@@ -657,9 +662,6 @@ const PremiumWebsite: React.FC = () => {
         </div>
       </section>
 
-      {/* Stats Section - Updated for GitHub Pages */}
-      <Stats />
-
       {/* Contact Section */}
       <section id="contact" className="relative z-10 py-20 px-6">
         <div className="mx-auto max-w-4xl text-center">
@@ -721,7 +723,7 @@ const PremiumWebsite: React.FC = () => {
         <div className="mx-auto max-w-7xl text-center text-sm text-muted-foreground font-['Open_Sans']">
           <div className="flex justify-center items-center mb-4">
             <Image
-              src={getAssetPath("/uploads/logo_2d.png")}
+              src={getAssetPath('/uploads/logo_2d.png')}
               alt="Hajila Bau Logo"
               width={48}
               height={48}

--- a/src/components/ui/stats-section.tsx
+++ b/src/components/ui/stats-section.tsx
@@ -17,64 +17,72 @@ function Stats() {
 
         {/* Stats Grid */}
         <div className="grid text-center grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 w-full gap-6 lg:gap-8">
-          <div className="flex gap-0 flex-col justify-between items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
-            <div className="p-3 rounded-full bg-primary/10 mb-6">
-              <Building2 className="w-8 h-8 text-primary" />
+          <div className="glow-border rounded-xl">
+            <div className="relative flex gap-0 flex-col justify-between items-center p-8 rounded-[inherit] border border-border/50 bg-card/50 backdrop-blur-sm transition-all duration-300 hover:scale-[1.02]">
+              <div className="p-3 rounded-full bg-primary/10 mb-6">
+                <Building2 className="w-8 h-8 text-primary" />
+              </div>
+              <h3 className="text-4xl lg:text-5xl tracking-tighter font-bold text-foreground mb-2">
+                150+
+              </h3>
+              <p className="text-lg font-medium text-muted-foreground">
+                Erfolgreich abgeschlossene Projekte
+              </p>
+              <p className="text-sm text-muted-foreground/80 mt-1">
+                Seit Firmengründung
+              </p>
             </div>
-            <h3 className="text-4xl lg:text-5xl tracking-tighter font-bold text-foreground mb-2">
-              150+
-            </h3>
-            <p className="text-lg font-medium text-muted-foreground">
-              Erfolgreich abgeschlossene Projekte
-            </p>
-            <p className="text-sm text-muted-foreground/80 mt-1">
-              Seit Firmengründung
-            </p>
           </div>
 
-          <div className="flex gap-0 flex-col justify-between items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
-            <div className="p-3 rounded-full bg-success/10 mb-6">
-              <Users className="w-8 h-8 text-success" />
+          <div className="glow-border rounded-xl">
+            <div className="relative flex gap-0 flex-col justify-between items-center p-8 rounded-[inherit] border border-border/50 bg-card/50 backdrop-blur-sm transition-all duration-300 hover:scale-[1.02]">
+              <div className="p-3 rounded-full bg-success/10 mb-6">
+                <Users className="w-8 h-8 text-success" />
+              </div>
+              <h3 className="text-4xl lg:text-5xl tracking-tighter font-bold text-foreground mb-2">
+                500+
+              </h3>
+              <p className="text-lg font-medium text-muted-foreground">
+                Zufriedene Kunden
+              </p>
+              <p className="text-sm text-muted-foreground/80 mt-1">
+                Privatpersonen & Unternehmen
+              </p>
             </div>
-            <h3 className="text-4xl lg:text-5xl tracking-tighter font-bold text-foreground mb-2">
-              500+
-            </h3>
-            <p className="text-lg font-medium text-muted-foreground">
-              Zufriedene Kunden
-            </p>
-            <p className="text-sm text-muted-foreground/80 mt-1">
-              Privatpersonen & Unternehmen
-            </p>
           </div>
 
-          <div className="flex gap-0 flex-col justify-between items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
-            <div className="p-3 rounded-full bg-blue-500/10 mb-6">
-              <Hammer className="w-8 h-8 text-blue-600" />
+          <div className="glow-border rounded-xl">
+            <div className="relative flex gap-0 flex-col justify-between items-center p-8 rounded-[inherit] border border-border/50 bg-card/50 backdrop-blur-sm transition-all duration-300 hover:scale-[1.02]">
+              <div className="p-3 rounded-full bg-blue-500/10 mb-6">
+                <Hammer className="w-8 h-8 text-blue-600" />
+              </div>
+              <h3 className="text-4xl lg:text-5xl tracking-tighter font-bold text-foreground mb-2">
+                15+
+              </h3>
+              <p className="text-lg font-medium text-muted-foreground">
+                Jahre Erfahrung
+              </p>
+              <p className="text-sm text-muted-foreground/80 mt-1">
+                Im Baugewerbe
+              </p>
             </div>
-            <h3 className="text-4xl lg:text-5xl tracking-tighter font-bold text-foreground mb-2">
-              15+
-            </h3>
-            <p className="text-lg font-medium text-muted-foreground">
-              Jahre Erfahrung
-            </p>
-            <p className="text-sm text-muted-foreground/80 mt-1">
-              Im Baugewerbe
-            </p>
           </div>
 
-          <div className="flex gap-0 flex-col justify-between items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
-            <div className="p-3 rounded-full bg-yellow-500/10 mb-6">
-              <Trophy className="w-8 h-8 text-yellow-600" />
+          <div className="glow-border rounded-xl">
+            <div className="relative flex gap-0 flex-col justify-between items-center p-8 rounded-[inherit] border border-border/50 bg-card/50 backdrop-blur-sm transition-all duration-300 hover:scale-[1.02]">
+              <div className="p-3 rounded-full bg-yellow-500/10 mb-6">
+                <Trophy className="w-8 h-8 text-yellow-600" />
+              </div>
+              <h3 className="text-4xl lg:text-5xl tracking-tighter font-bold text-foreground mb-2">
+                100%
+              </h3>
+              <p className="text-lg font-medium text-muted-foreground">
+                Qualitätsgarantie
+              </p>
+              <p className="text-sm text-muted-foreground/80 mt-1">
+                Auf alle unsere Arbeiten
+              </p>
             </div>
-            <h3 className="text-4xl lg:text-5xl tracking-tighter font-bold text-foreground mb-2">
-              100%
-            </h3>
-            <p className="text-lg font-medium text-muted-foreground">
-              Qualitätsgarantie
-            </p>
-            <p className="text-sm text-muted-foreground/80 mt-1">
-              Auf alle unsere Arbeiten
-            </p>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- create `.glow-border` CSS utility for rotating gradient borders
- simplify stats section to use the new class

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test -- --runInBand`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6880f97c410883209b65de2ade4afe40