### PR TITLE
feat: add gradient glow utility for stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,22 @@
 # Changelog
 
+## [0.4.9] - 2025-07-25
+
+### Hinzugefügt
+
+- **Stats-Section**: Direkt nach dem Hero platziert
+- **Rainbow Glow**: Rotierender Farbverlauf um alle Statistik-Karten
+
+### Geändert
+
+- **Version auf 0.4.9 erhöht**: UI-Verbesserungen sichtbar
+
 ## [0.4.8] - 2025-07-20
 
 ### Hinzugefügt
+
 - **Vollständige Systemanalyse**: Komplette Bildkarussell-Implementierung analysiert und dokumentiert
-- **SEO-Optimierungen**: 
+- **SEO-Optimierungen**:
   - Sitemap-Generierung (`src/app/sitemap.ts`) für automatische Suchmaschinenindexierung
   - Robots.txt (`src/app/robots.ts`) für Crawler-Steuerung
   - MetadataBase-Konfiguration in `layout.tsx` für vollständige OpenGraph/Twitter Card Integration
@@ -16,14 +28,17 @@
 - **Memory Bank Update**: Aktuelle Systemanalyse und Erkenntnisse vollständig dokumentiert
 
 ### Behoben
+
 - **SEO-Metadaten**: Vollständige Integration von metadataBase für korrekte URL-Generierung
 - **Browser-Kompatibilität**: Sitemap und Robots.txt erfolgreich getestet
 
 ### Geändert
+
 - **Version auf 0.4.8 erhöht**: Systemanalyse-Update markiert
 - **Documentation**: Erweiterte Troubleshooting-Guides und Debug-Commands
 
 ### Technische Details
+
 - **Status**: System vollständig analysiert und produktionsreif
 - **Architektur**: Frontend/Backend/API/Storage vollständig dokumentiert
 - **Sicherheit**: RLS-Policies, UUID-basierte Dateinamen, Input-Validierung
@@ -32,27 +47,31 @@
 ## [0.4.7] - 2025-07-19
 
 ### Hinzugefügt
+
 - **Kritischer Deployment-Fix**: Hybrid-Deployment-Strategie implementiert
   - Bedingte Aktivierung von `output: 'export'` nur für GitHub Pages (NEXT_PUBLIC_GITHUB_PAGES=true)
   - API-Routen für lokale Entwicklung wieder verfügbar
 - **Storage-Integration korrigiert**: Bucket-Name von `carousel_gallery` zu `carousel-gallery` standardisiert
 - **Vollständige API-Funktionalität wiederhergestellt**:
   - `/api/admin/carousel/upload` - Funktionsfähig
-  - `/api/admin/carousel/update` - Funktionsfähig  
+  - `/api/admin/carousel/update` - Funktionsfähig
   - `/api/admin/carousel/delete` - Funktionsfähig
 
 ### Behoben
+
 - **Kritischer Fix**: Statischer Export blockierte alle API-Routen - durch bedingte Konfiguration gelöst
 - **Storage-Bucket-Integration**: Korrekte Bucket-Namen-Konsistenz zwischen Code und Supabase
 - **Admin-Dashboard**: Login und Authentifizierung vollständig funktionsfähig
 - **Browser-Tests**: Admin-Login, API-Verfügbarkeit bestätigt
 
 ### Geändert
+
 - **next.config.ts**: Bedingte Export-Konfiguration für flexible Deployment-Optionen
 - **carousel-storage.ts**: Bucket-Namen auf `carousel-gallery` standardisiert
 - **Fehlerbehandlung**: Rollback-Mechanismen in Upload-APIs implementiert
 
 ### Technische Meilensteine
+
 - **Content Management System**: Vollständig funktionsfähiges Admin-Dashboard
 - **CRUD-Operationen**: Komplette Bildverwaltung mit Metadaten-Bearbeitung
 - **Produktionsbereit**: System bereit für Supabase-Produktivkonfiguration
@@ -60,6 +79,7 @@
 ## [0.4.6] - 2025-07-18
 
 ### Hinzugefügt
+
 - Implementierung der Bildercarousel-Verwaltung im Admin-Dashboard. Dies beinhaltet:
   - Anzeige und Verwaltung von Bildern über Supabase Storage und die `carousel_images_metadata`-Tabelle
   - Funktionalität zum Hochladen, Löschen, Aktualisieren von Metadaten (Titel, Beschreibung, Alt-Text, Aktivierungsstatus) und Vorschau von Bildern
@@ -67,17 +87,20 @@
 - Erstellung der fehlenden Memory-Bank-Dateien (`projectbrief.md`, `systemPatterns.md`, `techContext.md`, `progress.md`)
 
 ### Behoben
+
 - Behebung von Markdown-Linting-Fehlern (MD022, MD032, MD036, MD034) in allen Memory-Bank-Dateien und der `README.md`
 - Behebung des Cookie-Banner-Hintergrunds in `src/components/ui/premium-website.tsx`
 - Korrektur der Position der Überschrift "Unsere Leistungen" in `src/components/ui/premium-website.tsx`
 - Behebung von Hydration-Mismatch-Problemen bei Image-Komponenten in `src/components/ui/premium-website.tsx` durch Hinzufügen von `className="rounded-none"` und `priority`
 
 ### Geändert
+
 - Aktualisierung der Memory-Bank-Dateien mit aktuellen Informationen zu ungelösten Problemen (Supabase-Autorisierung, Submodul-Commits)
 
 ## [0.4.5] - 2025-07-16
 
 ### Behoben
+
 - Behebung des "null.from" Fehlers in `premium-website.tsx` durch robustere API-Abfrage
 - Behebung des "Cannot read properties of null (reading 'auth')" Fehlers in `AuthProvider.tsx` durch Prüfung auf `supabase`
 - Hinzufügung eines Buffer-Polyfills in `polyfills.ts` und Import in `AuthProvider.tsx`
@@ -87,24 +110,28 @@
 ## [0.4.2] - 2025-07-05
 
 ### Geändert
+
 - Logo und Favicon auf transparentes `logo_2d.png` gesetzt
 - Memory Bank und Changelog gepflegt
 
 ## [0.4.1] - 2025-07-05
 
 ### Hinzugefügt
+
 - Statischer Export für GitHub Pages, basePath/assetPrefix überall korrekt
 - AnimatedButton und Logo3D überall integriert
 - Karussell zeigt alle Bilder aus Upload-Ordner automatisch
 
 ### Geändert
+
 - MCP-Memory Bank und Changelog gepflegt
 
 ## [0.3.0] - 2025-07-03
 
 ### Hinzugefügt
+
 - **Supabase Photo Storage System** - Vollständiges Foto-Management mit API-Endpunkten
-- **Mock Storage System** - Demo-Funktionalität ohne externe Abhängigkeiten  
+- **Mock Storage System** - Demo-Funktionalität ohne externe Abhängigkeiten
 - **Jest Testing Framework** - 16 Unit-Tests und E2E-Workflows
 - **Admin Dashboard Erweiterungen** - Erweiterte Content-Management-Funktionen
 - **TypeScript Optimierungen** - 100% Typierung und Strict Mode
@@ -114,6 +141,7 @@
 ## [0.2.0] - 2025-01-15
 
 ### Hinzugefügt
+
 - **Content Management System** - Bilder-Karussell und Admin-Dashboard
 - **Firebase Integration** - Storage und Admin SDK für Bildverwaltung
 - **Drag & Drop Upload** - Intuitive Bildverwaltung mit Sortierung
@@ -121,6 +149,7 @@
 ## [0.1.0] - 2025-01-02
 
 ### Hinzugefügt
+
 - **Initiale Website-Erstellung** - Next.js 15 mit TypeScript und Tailwind CSS
 - **Premium Glassmorphism-Design** - 3D-Effekte und moderne Optik
 - **Responsive Design** - Optimiert für alle Bildschirmgrößen
@@ -132,13 +161,16 @@
 ## 🔐 Supabase Authentifizierung
 
 ### Authentifizierung-Features
+
 - Admin-Bereich und API sind mit Supabase Auth geschützt
 - E-Mail/Passwort-Login und Google Login im Admin-Bereich
 - Logout-Button oben rechts im Admin
 - API-Requests müssen den Bearer-Token mitsenden (siehe Beispiel in `src/app/api/admin/images/route.ts`)
 
 ### Environment-Variablen
+
 Erforderliche Umgebungsvariablen in `.env.local`:
+
 ```env
 NEXT_PUBLIC_SUPABASE_URL=...
 NEXT_PUBLIC_SUPABASE_ANON_KEY=...
@@ -146,6 +178,7 @@ SUPABASE_SERVICE_ROLE_KEY=...
 ```
 
 ### Sicherheitsfeatures
+
 - Row Level Security (RLS) Policies für alle Datenbankoperationen
 - UUID-basierte Dateinamen für Upload-Sicherheit
 - Input-Validierung und Sanitisierung

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,9 +1,11 @@
 # Aktueller Kontext
 
 ## Aktuelle Arbeit
+
 **ABGESCHLOSSEN**: Vollständige Analyse und Dokumentation der Bildkarussell-Implementierung im Admin-Dashboard. Das System ist vollständig funktionsfähig und produktionsreif. Umfassende Systemanalyse inklusive aller Routen, Komponenten und Browser-Tests durchgeführt.
 
 ## Letzte Änderungen
+
 - **Vollständige Systemanalyse abgeschlossen**: Alle Komponenten, API-Routen und Storage-Integration analysiert
 - **Browser-Tests erfolgreich**: Admin-Login, Sitemap (/sitemap.xml), Robots.txt (/robots.txt) funktionieren
 - **SEO-Optimierungen**: metadataBase hinzugefügt, vollständige OpenGraph/Twitter Card Integration
@@ -11,23 +13,28 @@
 - **Memory Bank Update**: Aktuelle Systemanalyse und Erkenntnisse dokumentiert
 
 ## Nächste Schritte
-- **AKTIV**: Version auf v0.4.8 erhöhen (Systemanalyse-Update)
+
+- **AKTIV**: Version auf v0.4.9 erhöhen (Stats-Section-Update)
 - **AKTIV**: Memory Bank und MCP Update durchführen
+- **NEU**: Stats-Section direkt nach dem Hero mit rotierendem Rainbow-Glow
 - Git-Commit mit vollständiger Systemanalyse
 - Produktionskonfiguration in Supabase (Admin-User, Storage-Bucket, SQL-Schema)
 
 ## Aktive Entscheidungen und Überlegungen
+
 - **Hybrid-Deployment-Strategie**: Statischer Export nur für GitHub Pages, volle Server-Funktionalität für lokale Entwicklung
 - **Supabase-Integration**: Vollständig konfiguriert mit Auth, Storage und Datenbank
 - **Admin-Dashboard-Architektur**: Vollständig implementiert mit Upload-Zone, CRUD-Operationen, Tab-Navigation
 
 ## Wichtige Muster und Präferenzen
+
 - **Fehlerbehandlung**: Rollback-Mechanismen in Upload-APIs implementiert
 - **Sicherheit**: UUID-basierte Dateinamen, Row Level Security vorbereitet
 - **UX**: Drag & Drop, Inline-Bearbeitung, responsive Design
 - **Code-Qualität**: TypeScript-Interfaces, error boundary patterns
 
 ## Lernerfahrungen und Einblicke in das Projekt
+
 - **Next.js Output-Modi**: Statischer Export verhindert API-Routen vollständig
 - **Supabase Storage**: Bucket-Namen müssen exakt zwischen Code und Dashboard übereinstimmen
 - **React Server Components**: Authentifizierung erfordert client-seitige Komponenten

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -3,6 +3,7 @@
 ## Was funktioniert ✅
 
 ### Grundlegende Infrastruktur
+
 - Next.js 15 Setup mit React 19
 - TypeScript-Konfiguration
 - Tailwind CSS mit modernen UI-Komponenten
@@ -10,6 +11,7 @@
 - Jest-Setup für Testing
 
 ### UI/UX Komponenten
+
 - Responsive Design mit Tailwind
 - Animierte Komponenten mit Framer Motion
 - Glassmorphismus-Effekte
@@ -17,18 +19,21 @@
 - Moderne Button-Komponenten mit Liquid-Effekten
 
 ### Authentifizierung & Sicherheit
+
 - Supabase Auth-Integration ✅
 - Login/Logout-Funktionalität ✅
 - Admin-Dashboard-Schutz ✅
 - Row Level Security (RLS) Policies vorbereitet
 
 ### Storage & Datenmanagement
+
 - Supabase Storage für Bilddateien ✅
 - Carousel-Image-Metadaten-Verwaltung ✅
 - Automatische URL-Generierung ✅
 - UUID-basierte Dateinamengenerierung ✅
 
 ### Admin-Dashboard
+
 - Vollständiges CRUD-Interface für Carousel-Bilder ✅
 - Drag & Drop Upload-Funktionalität ✅
 - Bildmetadaten-Bearbeitung ✅
@@ -37,12 +42,14 @@
 - Statistik-Dashboard (Bilder, Speicher, etc.) ✅
 
 ### API-Routen
+
 - `/api/admin/carousel/upload` - Bild-Upload ✅
 - `/api/admin/carousel/update` - Metadaten-Updates ✅
 - `/api/admin/carousel/delete` - Bild-Löschung ✅
 - Error-Handling und Rollback-Mechanismen ✅
 
 ### Frontend-Karussell
+
 - Animiertes Bilderkarussell mit 3D-Effekten ✅
 - Touch/Swipe-Navigation ✅
 - Automatisches Abspielen ✅
@@ -50,12 +57,14 @@
 - Responsive Design ✅
 
 ### Rechtliche Seiten
+
 - Impressum-Seite ✅
 - Datenschutzerklärung ✅
 - Cookie-Hinweise ✅
 - Vollständige rechtliche Compliance ✅
 
 ### Deployment & CI/CD
+
 - GitHub Pages Integration ✅
 - Hybrid-Deployment-Strategie (statisch für GitHub, Server für Development) ✅
 - Environment-spezifische Konfigurationen ✅
@@ -63,50 +72,59 @@
 ## Was noch konfiguriert werden muss 🔧
 
 ### Supabase-Produktivkonfiguration
+
 - [ ] Admin-User in Supabase erstellen
 - [ ] Storage-Bucket `carousel-gallery` anlegen
 - [ ] SQL-Schema ausführen (`docs/supabase_carousel_setup.sql`)
 - [ ] Google OAuth konfigurieren (optional)
 
 ### Content Management
+
 - [ ] Initialer Bildcontent für Carousel hochladen
 - [ ] SEO-Metadaten für alle Seiten
 - [ ] Sitemap-Generierung
 - [ ] Rich Snippets/Schema Markup
 
 ### Performance & Monitoring
+
 - [ ] Image-Optimization Pipeline
 - [ ] Performance-Monitoring
 - [ ] Error-Tracking/Logging
 - [ ] Analytics-Integration
 
 ### Erweiterte Features (Optional)
+
 - [ ] Bildkomprimierung/Optimierung
 - [ ] Bulk-Upload-Funktionalität
 - [ ] Bildsorting per Drag & Drop im Admin
 - [ ] Backup/Export-Funktionen
 
 ### Testing & Qualität
+
 - [ ] Unit Tests für alle Komponenten
 - [ ] Integration Tests für API-Routen
 - [ ] E2E Tests für Admin-Workflows
 - [ ] Performance Tests
 
-## Aktueller Status (v0.4.8)
+## Aktueller Status (v0.4.9)
 
 ### Kürzlich Abgeschlossen
+
 - ✅ **Vollständige Systemanalyse**: Komplette Bildkarussell-Implementierung analysiert und dokumentiert
 - ✅ **Architektur-Dokumentation**: Frontend/Backend/API/Storage vollständig dokumentiert
 - ✅ **Browser-Testing abgeschlossen**: Admin-Login, SEO-Features (Sitemap, Robots.txt) getestet
 - ✅ **SEO-Optimierung**: metadataBase konfiguriert, alle Metadaten vollständig
-- ✅ **Memory Bank vollständig aktualisiert**: Aktuelle Systemanalyse dokumentiert
+  - ✅ **Memory Bank vollständig aktualisiert**: Aktuelle Systemanalyse dokumentiert
+  - ✅ **Stats-Section mit Rainbow-Glow**: Direkt nach dem Hero platziert
 
 ### Aktuelle Arbeit
-- 🔄 Versionierung auf v0.4.8 (Systemanalyse-Update)
+
+- 🔄 Versionierung auf v0.4.9 (Stats-Section-Update)
 - 🔄 Git-Commit der vollständigen Dokumentation
 - 🔄 MCP Memory Update durchführen
 
 ### Nächste Prioritäten
+
 1. Supabase-Produktivkonfiguration abschließen
 2. Initialer Content-Upload ins Carousel
 3. SEO-Optimierung und Metadaten
@@ -115,12 +133,14 @@
 ## Projektevolution
 
 ### Meilensteine
+
 **v0.4.0-0.4.6**: Grundlegende Webseite mit statischem Content
 **v0.4.7**: Vollständiges Content-Management-System mit Admin-Dashboard
 
 Das Projekt hat sich erfolgreich von einer statischen Webseite zu einem professionellen CMS mit Supabase-Backend entwickelt. Die Admin-Dashboard-Funktionalität ist vollständig implementiert und getestet.
 
 ### Technische Entscheidungen
+
 - **Next.js 15**: Moderne React-Features, flexible Deployment-Optionen
 - **Supabase**: Professionelles Backend-as-a-Service (Auth, DB, Storage)
 - **TypeScript**: Typsicherheit und bessere Entwicklererfahrung
@@ -128,6 +148,7 @@ Das Projekt hat sich erfolgreich von einer statischen Webseite zu einem professi
 - **Framer Motion**: Professionelle Animationen und Übergänge
 
 ### Architektonische Patterns
+
 - **Hybrid-Deployment**: Statisch für GitHub Pages, Server für Development
 - **Component-based Architecture**: Modulare, wiederverwendbare UI
 - **API-First Design**: RESTful APIs für alle Backend-Operationen
@@ -135,11 +156,13 @@ Das Projekt hat sich erfolgreich von einer statischen Webseite zu einem professi
 - **Error-Resilience**: Graceful degradation, Rollback-Mechanismen
 
 ### Bekannte Issues
+
 - **Google OAuth**: Nicht in Supabase konfiguriert (E-Mail/Passwort funktioniert)
 - **Initial Setup**: Produktiv-Konfiguration in Supabase erforderlich
 - **Content**: Initialer Bildcontent muss hochgeladen werden
 
 ### Technische Schulden
+
 - Minimal - Code ist gut strukturiert und dokumentiert
 - Testing-Coverage könnte erweitert werden
 - Performance-Monitoring implementieren

--- a/memory-bank/summary.txt
+++ b/memory-bank/summary.txt
@@ -1,9 +1,11 @@
 # Zusammenfassung des aktuellen Fortschritts für Hajila Bau Webseite
 
 ## Projektstatus
+
 Die Hajila Bau Webseite befindet sich in der Entwicklung. Der aktuelle Fokus liegt auf der Pflege der Speicherbank und der Stabilisierung des Build-Prozesses.
 
 ## Aktuelle Dateien im Projekt
+
 Die folgenden Dateien sind relevant für das Projekt:
 
 1. `memory-bank/projectbrief.md` - Definiert die Kernanforderungen und Ziele für die Hajila Bau Webseite.
@@ -13,24 +15,28 @@ Die folgenden Dateien sind relevant für das Projekt:
 5. `src/app/api/memory/route.ts` - API-Endpoint für den Zugriff auf die Wissensdatenbank.
 
 ## Aktuelle Änderungen
+
 - Aktualisierung der Regeln in `memory-bank/rules.md`
 - Weiterentwicklung der Komponenten in `src/components/ui/...`
 - Implementierung neuer API-Endpoints in `src/app/api/...`
 - Behebung des ESLint-Fehlers "A `require()` style import is forbidden." durch Migration der Next.js-Konfiguration von `next.config.js` nach `next.config.ts` und Korrektur des `ProvidePlugin`-Imports.
 - Behebung des Fehlers "Doppelter Objektschlüssel" in `package.json` durch Entfernen des doppelten "buffer"-Eintrags.
-- Aktualisierung der Version in `package.json` auf 0.4.5.
-- Aktualisierung des Changelogs auf Version 0.4.5.
+  - Aktualisierung der Version in `package.json` auf 0.4.9.
+  - Aktualisierung des Changelogs auf Version 0.4.9.
 - Aufnahme der `buffer`-Abhängigkeit und Anpassung der Webpack-Konfiguration.
 - Erfolgreicher Test- und Build-Lauf sichert die Funktionalität.
 - Supabase-Verbindung per cURL getestet; Node-basierte Tests scheiterten am Proxy.
-- Zwei Testnutzer (Michael und Erko) wurden in Supabase angelegt.
+  - Zwei Testnutzer (Michael und Erko) wurden in Supabase angelegt.
+  - Neue Stats-Section mit rotierendem Rainbow-Glow eingefügt.
 
 ## Nächste Schritte
+
 1. Überprüfung der Barrierefreiheit und SEO-Optimierung
 2. Integration der neuen Regeln in den Code
 3. Test und Optimierung der Laderate der Webseite
 
 ## Beobachtungen
+
 - Die Webseite nutzt Next.js und TypeScript für eine reibungslose Benutzererfahrung.
 - Die Memory Bank wird ständig erweitert, um den Kontext für zukünftige Entwicklungen zu sichern.
 - Es gibt keine Cloud-Synchronisation oder automatischen Backups, daher ist regelmäßige manuelle Sicherung wichtig.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hajila-website",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hajila-website",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "dependencies": {
         "@21st-extension/react": "^0.5.6",
         "@21st-extension/toolbar-next": "^0.5.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hajila-website",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @custom-variant dark (&:is(.dark *));
 
@@ -82,10 +82,10 @@
 
   /* Custom Colors for Hajila Bau */
   --blue-start: #000080; /* Dunkelblau */
-  --blue-end: #4169E1;   /* Royalblau */
-  --gold: #FFD700;       /* Gold */
-  --blue-500: #3B82F6;   /* Tailwind blue-500 */
-  --purple-600: #9333EA; /* Tailwind purple-600 */
+  --blue-end: #4169e1; /* Royalblau */
+  --gold: #ffd700; /* Gold */
+  --blue-500: #3b82f6; /* Tailwind blue-500 */
+  --purple-600: #9333ea; /* Tailwind purple-600 */
 }
 
 .dark {
@@ -125,10 +125,10 @@
 
   /* Custom Colors for Hajila Bau in Dark Mode */
   --blue-start: #000080; /* Dunkelblau */
-  --blue-end: #4169E1;   /* Royalblau */
-  --gold: #FFD700;       /* Gold */
-  --blue-500: #3B82F6;   /* Tailwind blue-500 */
-  --purple-600: #9333EA; /* Tailwind purple-600 */
+  --blue-end: #4169e1; /* Royalblau */
+  --gold: #ffd700; /* Gold */
+  --blue-500: #3b82f6; /* Tailwind blue-500 */
+  --purple-600: #9333ea; /* Tailwind purple-600 */
 }
 
 @layer base {
@@ -137,5 +137,26 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@keyframes spin-slow {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@layer utilities {
+  .animate-spin-slow {
+    animation: spin-slow 8s linear infinite;
+  }
+
+  .glow-border {
+    position: relative;
+    overflow: hidden;
+    padding: 1px;
   }
 }

--- a/src/components/ui/premium-website.tsx
+++ b/src/components/ui/premium-website.tsx
@@ -394,7 +394,7 @@ const PremiumWebsite: React.FC = () => {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Image
-                src={getAssetPath("/uploads/logo_2d.png")}
+                src={getAssetPath('/uploads/logo_2d.png')}
                 alt="Hajila Bau Logo"
                 width={48}
                 height={48}
@@ -500,6 +500,9 @@ const PremiumWebsite: React.FC = () => {
         </div>
       </section>
 
+      {/* Stats Section */}
+      <Stats />
+
       {/* Services Section (Features) - Integrated with GlowingServiceGrid */}
       <section id="services" className="relative z-10 py-20 px-6">
         <div className="mx-auto max-w-7xl">
@@ -582,7 +585,9 @@ const PremiumWebsite: React.FC = () => {
             className="flex justify-center mb-12"
           >
             <Image
-              src={getAssetPath("/uploads/Baustelle mit HB Logo und Mauern.png")}
+              src={getAssetPath(
+                '/uploads/Baustelle mit HB Logo und Mauern.png',
+              )}
               alt="Baustelle mit Hajila Bau Logo"
               width={800}
               height={450}
@@ -657,9 +662,6 @@ const PremiumWebsite: React.FC = () => {
         </div>
       </section>
 
-      {/* Stats Section - Updated for GitHub Pages */}
-      <Stats />
-
       {/* Contact Section */}
       <section id="contact" className="relative z-10 py-20 px-6">
         <div className="mx-auto max-w-4xl text-center">
@@ -721,7 +723,7 @@ const PremiumWebsite: React.FC = () => {
         <div className="mx-auto max-w-7xl text-center text-sm text-muted-foreground font-['Open_Sans']">
           <div className="flex justify-center items-center mb-4">
             <Image
-              src={getAssetPath("/uploads/logo_2d.png")}
+              src={getAssetPath('/uploads/logo_2d.png')}
               alt="Hajila Bau Logo"
               width={48}
               height={48}

--- a/src/components/ui/stats-section.tsx
+++ b/src/components/ui/stats-section.tsx
@@ -1,5 +1,8 @@
 import { Building2, Hammer, Users, Trophy } from 'lucide-react'
 
+const RAINBOW_GRADIENT =
+  'conic-gradient(#ff0000,#ff8800,#ffff00,#88ff00,#00ff00,#00ff88,#00ffff,#0088ff,#0000ff,#8800ff,#ff00ff,#ff0088,#ff0000)'
+
 function Stats() {
   return (
     <div className="w-full py-20 lg:py-40 bg-gradient-to-br from-background via-background to-muted/30">
@@ -17,64 +20,96 @@ function Stats() {
 
         {/* Stats Grid */}
         <div className="grid text-center grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 w-full gap-6 lg:gap-8">
-          <div className="flex gap-0 flex-col justify-between items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
-            <div className="p-3 rounded-full bg-primary/10 mb-6">
-              <Building2 className="w-8 h-8 text-primary" />
+          <div className="glow-border rounded-xl">
+            <div
+              className="pointer-events-none absolute inset-0 rounded-[inherit] opacity-70 blur-md animate-spin-slow"
+              style={{
+                background: RAINBOW_GRADIENT,
+              }}
+            />
+            <div className="relative flex gap-0 flex-col justify-between items-center p-8 rounded-[inherit] border border-border/50 bg-card/50 backdrop-blur-sm transition-all duration-300 hover:scale-[1.02]">
+              <div className="p-3 rounded-full bg-primary/10 mb-6">
+                <Building2 className="w-8 h-8 text-primary" />
+              </div>
+              <h3 className="text-4xl lg:text-5xl tracking-tighter font-bold text-foreground mb-2">
+                150+
+              </h3>
+              <p className="text-lg font-medium text-muted-foreground">
+                Erfolgreich abgeschlossene Projekte
+              </p>
+              <p className="text-sm text-muted-foreground/80 mt-1">
+                Seit Firmengründung
+              </p>
             </div>
-            <h3 className="text-4xl lg:text-5xl tracking-tighter font-bold text-foreground mb-2">
-              150+
-            </h3>
-            <p className="text-lg font-medium text-muted-foreground">
-              Erfolgreich abgeschlossene Projekte
-            </p>
-            <p className="text-sm text-muted-foreground/80 mt-1">
-              Seit Firmengründung
-            </p>
           </div>
 
-          <div className="flex gap-0 flex-col justify-between items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
-            <div className="p-3 rounded-full bg-success/10 mb-6">
-              <Users className="w-8 h-8 text-success" />
+          <div className="glow-border rounded-xl">
+            <div
+              className="pointer-events-none absolute inset-0 rounded-[inherit] opacity-70 blur-md animate-spin-slow"
+              style={{
+                background: RAINBOW_GRADIENT,
+              }}
+            />
+            <div className="relative flex gap-0 flex-col justify-between items-center p-8 rounded-[inherit] border border-border/50 bg-card/50 backdrop-blur-sm transition-all duration-300 hover:scale-[1.02]">
+              <div className="p-3 rounded-full bg-success/10 mb-6">
+                <Users className="w-8 h-8 text-success" />
+              </div>
+              <h3 className="text-4xl lg:text-5xl tracking-tighter font-bold text-foreground mb-2">
+                500+
+              </h3>
+              <p className="text-lg font-medium text-muted-foreground">
+                Zufriedene Kunden
+              </p>
+              <p className="text-sm text-muted-foreground/80 mt-1">
+                Privatpersonen & Unternehmen
+              </p>
             </div>
-            <h3 className="text-4xl lg:text-5xl tracking-tighter font-bold text-foreground mb-2">
-              500+
-            </h3>
-            <p className="text-lg font-medium text-muted-foreground">
-              Zufriedene Kunden
-            </p>
-            <p className="text-sm text-muted-foreground/80 mt-1">
-              Privatpersonen & Unternehmen
-            </p>
           </div>
 
-          <div className="flex gap-0 flex-col justify-between items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
-            <div className="p-3 rounded-full bg-blue-500/10 mb-6">
-              <Hammer className="w-8 h-8 text-blue-600" />
+          <div className="glow-border rounded-xl">
+            <div
+              className="pointer-events-none absolute inset-0 rounded-[inherit] opacity-70 blur-md animate-spin-slow"
+              style={{
+                background: RAINBOW_GRADIENT,
+              }}
+            />
+            <div className="relative flex gap-0 flex-col justify-between items-center p-8 rounded-[inherit] border border-border/50 bg-card/50 backdrop-blur-sm transition-all duration-300 hover:scale-[1.02]">
+              <div className="p-3 rounded-full bg-blue-500/10 mb-6">
+                <Hammer className="w-8 h-8 text-blue-600" />
+              </div>
+              <h3 className="text-4xl lg:text-5xl tracking-tighter font-bold text-foreground mb-2">
+                15+
+              </h3>
+              <p className="text-lg font-medium text-muted-foreground">
+                Jahre Erfahrung
+              </p>
+              <p className="text-sm text-muted-foreground/80 mt-1">
+                Im Baugewerbe
+              </p>
             </div>
-            <h3 className="text-4xl lg:text-5xl tracking-tighter font-bold text-foreground mb-2">
-              15+
-            </h3>
-            <p className="text-lg font-medium text-muted-foreground">
-              Jahre Erfahrung
-            </p>
-            <p className="text-sm text-muted-foreground/80 mt-1">
-              Im Baugewerbe
-            </p>
           </div>
 
-          <div className="flex gap-0 flex-col justify-between items-center p-8 rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
-            <div className="p-3 rounded-full bg-yellow-500/10 mb-6">
-              <Trophy className="w-8 h-8 text-yellow-600" />
+          <div className="glow-border rounded-xl">
+            <div
+              className="pointer-events-none absolute inset-0 rounded-[inherit] opacity-70 blur-md animate-spin-slow"
+              style={{
+                background: RAINBOW_GRADIENT,
+              }}
+            />
+            <div className="relative flex gap-0 flex-col justify-between items-center p-8 rounded-[inherit] border border-border/50 bg-card/50 backdrop-blur-sm transition-all duration-300 hover:scale-[1.02]">
+              <div className="p-3 rounded-full bg-yellow-500/10 mb-6">
+                <Trophy className="w-8 h-8 text-yellow-600" />
+              </div>
+              <h3 className="text-4xl lg:text-5xl tracking-tighter font-bold text-foreground mb-2">
+                100%
+              </h3>
+              <p className="text-lg font-medium text-muted-foreground">
+                Qualitätsgarantie
+              </p>
+              <p className="text-sm text-muted-foreground/80 mt-1">
+                Auf alle unsere Arbeiten
+              </p>
             </div>
-            <h3 className="text-4xl lg:text-5xl tracking-tighter font-bold text-foreground mb-2">
-              100%
-            </h3>
-            <p className="text-lg font-medium text-muted-foreground">
-              Qualitätsgarantie
-            </p>
-            <p className="text-sm text-muted-foreground/80 mt-1">
-              Auf alle unsere Arbeiten
-            </p>
           </div>
         </div>
 


### PR DESCRIPTION
### **User description**
## Summary
- simplify `glow-border` utility
- animate rainbow glow around each stat card
- centralize gradient constant in stats component
- bump version to 0.4.9 and document the change

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test -- --runInBand`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6880f97c410883209b65de2ade4afe40


___

### **PR Type**
Enhancement


___

### **Description**
- Add animated rainbow glow effect to stats cards

- Move stats section directly after hero section

- Simplify glow-border utility with CSS animations

- Update version to 0.4.9 with changelog documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Stats Section"] --> B["Rainbow Gradient"]
  B --> C["Rotating Animation"]
  C --> D["Glow Border Effect"]
  E["CSS Utilities"] --> F["animate-spin-slow"]
  F --> G["glow-border class"]
  H["Version Update"] --> I["0.4.9 Release"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody></tr></tbody></table>

</details>

___

